### PR TITLE
Added the use of the default/runtime seccomp profile.

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,7 +1,3 @@
-# Affects all versions of archiver which is required by vault.
-# Taken from: https://github.com/giantswarm/opsctl/pull/1072/files#diff-bbe4a7fb12c43622bce7c6840c770e9995be614626a219942ca138403629cb69R1
-CVE-2019-10743 until=2021-10-17
-
 CVE-2022-29153
 sonatype-2021-1401
 sonatype-2019-0890
@@ -9,4 +5,7 @@ CVE-2022-21698
 CVE-2021-20329
 
 # It is an issue in the current latest v0.26.0 as well
-sonatype-2022-6522 until=2023-02-01
+sonatype-2022-6522 until=2023-06-01
+
+# Some dependencies still require an old version of x/net
+CVE-2022-41723 until=2023-06-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add the use of the runtime/default seccomp profile.
+
 ## [0.3.0] - 2023-01-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add the use of the runtime/default seccomp profile.
+- Add the use of the runtime/default seccomp profile. Allow required volume types in PSP so that pods can still be admitted.
 
 ## [0.3.0] - 2023-01-31
 

--- a/helm/encryption-provider-operator/templates/deployment.yaml
+++ b/helm/encryption-provider-operator/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
+        {{- with .Values.podSecurityContext }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
@@ -34,6 +37,10 @@ spec:
         - --key-rotation-period={{.Values.encryptionProvider.keyRotationPeriod}}
         - --registry-domain={{ .Values.registry.domain }}
         - --from-release-version={{.Values.encryptionProvider.fromRelease}}
+        securityContext:
+          {{- with .Values.securityContext }}
+            {{- . | toYaml | nindent 10 }}
+          {{- end }}
         resources:
           requests:
             cpu: 150m

--- a/helm/encryption-provider-operator/templates/psp.yaml
+++ b/helm/encryption-provider-operator/templates/psp.yaml
@@ -2,6 +2,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "resource.psp.name" . }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/encryption-provider-operator/templates/psp.yaml
+++ b/helm/encryption-provider-operator/templates/psp.yaml
@@ -24,6 +24,9 @@ spec:
     rule: RunAsAny
   supplementalGroups:
     rule: RunAsAny
+  volumes:
+    # Needed for Kubernetes API access (https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
+    - projected
   allowPrivilegeEscalation: false
   hostNetwork: false
   hostIPC: false

--- a/helm/encryption-provider-operator/values.yaml
+++ b/helm/encryption-provider-operator/values.yaml
@@ -16,3 +16,13 @@ pod:
     id: 1000
   group:
     id: 1000
+
+# Add seccomp to pod security context
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+# Add seccomp to container security context
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault


### PR DESCRIPTION
I've modified the container and pod securitycontexts to let this application make use of the runtime/default seccomp profile. During testing this did not seem to interrupt any functionality. Please confirm this if possible.
This is done in light of:

https://github.com/giantswarm/roadmap/issues/259

Drop a message on slack if you've got questions.